### PR TITLE
Futures domain change

### DIFF
--- a/src/DoubleBit/OKCoin/Okcoin.php
+++ b/src/DoubleBit/OKCoin/Okcoin.php
@@ -23,7 +23,7 @@ class Okcoin
         $method = $pieces[0];
         unset($pieces[0]);
         $endpoint = strtolower(implode('_', $pieces));
-        
+
         if (!isset($arguments[0]) || !is_string($arguments[0])) {
             $api_key = \Config::get('okcoin.api_key');
             $secret_key = \Config::get('okcoin.secret_key');
@@ -35,7 +35,7 @@ class Okcoin
             $params = $original_params = isset($arguments[2]) ? $arguments[2] : [];
             $callback = isset($arguments[3]) ? $arguments[3] : null;
         }
-        
+
         if ($api_key && $secret_key) {
             $params['api_key'] = $api_key;
             $signature = $this->sign($params, $secret_key);
@@ -55,7 +55,11 @@ class Okcoin
     public function callApi($method, $endpoint, $query)
     {
         $client = new \GuzzleHttp\Client();
-        $url = 'https://www.okcoin.com/api/' . \Config::get('okcoin.api_version') . '/' . $endpoint . '.do?' . $query;
+        $domain = stristr($endpoint, 'future') ?
+            \Config::get('okcoin.futures_domain') :
+            \Config::get('okcoin.domain');
+        $url = 'https://' . $domain . '/api/' . \Config::get('okcoin.api_version') .
+            '/' . $endpoint . '.do?' . $query;
         try {
             $res = $client->request($method, $url);
             if ($res->getStatusCode() != 200) {

--- a/src/DoubleBit/OKCoin/config/okcoin.php
+++ b/src/DoubleBit/OKCoin/config/okcoin.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'domain' => env('OKCOIN_DOMAIN', 'www.okcoin.com'),
+    'futures_domain' => env('OKCOIN_FUTURES_DOMAIN', 'www.okex.com'),
     'api_version' => env('OKCOIN_API_VERSION', 'v1'),
     'api_key' => env('OKCOIN_API_KEY', ''),
     'secret_key' => env('OKCOIN_SECRET_KEY', ''),


### PR DESCRIPTION
OKCoin are migrating the futures api to a new domain on May 30.

See http://blog.okcoin.com/post/161088088064/okcoin-to-migrate-futures-activity-to-okexcom
